### PR TITLE
skip startup for meteorhacks:cluster workers

### DIFF
--- a/cluster.js
+++ b/cluster.js
@@ -28,6 +28,10 @@ Cluster = {
   },
 
   startup: function() {
+    // skip for meteorhacks:cluster workers
+    if (process.env['CLUSTER_WORKER_ID']) {
+      return;
+    }
     if (settings.disable) return;
     if (this.isMaster) {
       if (settings.exec) {


### PR DESCRIPTION
To prevent conflicting with https://github.com/meteorhacks/cluster

Otherwise it will start separate differential clusters for each meteorhacks cluster worker.
